### PR TITLE
test adding resource hosts

### DIFF
--- a/build-images/basic/manager/startup-script.sh
+++ b/build-images/basic/manager/startup-script.sh
@@ -212,7 +212,8 @@ if [[ "X${brokerConfig}" != "X" ]]; then
    # We need to parse it directly into a file, otherwise will lose newlines
    echo "Found custom broker config"
    rm -rf /usr/local/etc/flux/system/conf.d/system.toml
-   curl "http://metadata.google.internal/computeMetadata/v1/instance/attributes/broker-config" -H "Metadata-Flavor: Google" > /usr/local/etc/flux/system/conf.d/system.toml
+   curl "http://metadata.google.internal/computeMetadata/v1/instance/attributes/broker-config" -H "Metadata-Flavor: Google" > /tmp/system.toml 
+   mv /tmp/system.toml /usr/local/etc/flux/system/conf.d/system.toml
    sudo chown -R flux /usr/local/etc/flux/system/conf.d
 fi
 
@@ -221,7 +222,8 @@ curveCert=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/at
 if [[ "X${curveCert}" != "X" ]]; then
    echo "Found custom curve.cert"
    rm -rf /usr/local/etc/flux/system/curve.cert
-   curl "http://metadata.google.internal/computeMetadata/v1/instance/attributes/curve-cert" -H "Metadata-Flavor: Google" > /usr/local/etc/flux/system/curve.cert
+   curl "http://metadata.google.internal/computeMetadata/v1/instance/attributes/curve-cert" -H "Metadata-Flavor: Google" > /tmp/curve.cert
+   mv /tmp/curve.cert /usr/local/etc/flux/system/curve.cert
    sudo chown flux /usr/local/etc/flux/system/curve.cert
 fi
 

--- a/build-images/basic/manager/startup-script.sh
+++ b/build-images/basic/manager/startup-script.sh
@@ -198,6 +198,16 @@ if [[ "X${brokerConfig}" != "X" ]]; then
    echo "Found custom broker config"
    rm -rf /usr/local/etc/flux/system/conf.d/system.toml
    curl "http://metadata.google.internal/computeMetadata/v1/instance/attributes/broker-config" -H "Metadata-Flavor: Google" > /usr/local/etc/flux/system/conf.d/system.toml
+   sudo chown -R flux /usr/local/etc/flux/system/conf.d
+fi
+
+# If we are given a custom curve.cert, use it
+curveCert=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/attributes/curve-cert" -H "Metadata-Flavor: Google")
+if [[ "X${curveCert}" != "X" ]]; then
+   echo "Found custom broker curve.cert"
+   rm -rf /usr/local/etc/flux/system/curve.cert
+   curl "http://metadata.google.internal/computeMetadata/v1/instance/attributes/curve-cert" -H "Metadata-Flavor: Google" > /usr/local/etc/flux/system/curve.cert
+   sudo chown flux /usr/local/etc/flux/system/curve.cert
 fi
 
 # Update FLUXMANAGER with actual hostname

--- a/build-images/basic/manager/startup-script.sh
+++ b/build-images/basic/manager/startup-script.sh
@@ -248,7 +248,7 @@ resourceHosts=$(curl "http://metadata.google.internal/computeMetadata/v1/instanc
 CORES=$(($(hwloc-ls -p | grep -i core | wc -l)-1))
 
 if [[ "X${resourceHosts}" != "X" ]]; then
-  /usr/local/bin/flux R encode --ranks=0 --hosts=${resourceHosts} --cores=0-$CORES --property=manager | tee /usr/local/etc/flux/system/R > /dev/null
+  /usr/local/bin/flux R encode --hosts=${resourceHosts} --cores=0-$CORES --property=manager | tee /usr/local/etc/flux/system/R > /dev/null
 else
   /usr/local/bin/flux R encode --ranks=0 --hosts=$(hostname -s) --cores=0-$CORES --property=manager | tee /usr/local/etc/flux/system/R > /dev/null
 fi

--- a/build-images/basic/manager/startup-script.sh
+++ b/build-images/basic/manager/startup-script.sh
@@ -187,6 +187,8 @@ chmod u+r,u-wx,go-rwx /usr/local/etc/flux/imp/conf.d/imp.toml
 chmod u+s /usr/local/libexec/flux/flux-imp
 
 mkdir -p /etc/flux/manager/conf.d
+mkdir -p /run/flux
+chown -R flux:flux /run/flux
 
 # A quick Python script for handling decoding
 
@@ -224,7 +226,8 @@ if [[ "X${curveCert}" != "X" ]]; then
    rm -rf /usr/local/etc/flux/system/curve.cert
    curl "http://metadata.google.internal/computeMetadata/v1/instance/attributes/curve-cert" -H "Metadata-Flavor: Google" > /tmp/curve.cert
    mv /tmp/curve.cert /usr/local/etc/flux/system/curve.cert
-   sudo chown flux /usr/local/etc/flux/system/curve.cert
+   sudo chmod u=r,g=,o= /usr/local/etc/flux/system/curve.cert
+   sudo chown flux:flux /usr/local/etc/flux/system/curve.cert
 fi
 
 # If we are given a custom munge.key, also use it. This is base64 encoded
@@ -234,6 +237,8 @@ if [[ "X${mungeKey}" != "X" ]]; then
    mkdir -p /etc/munge
    rm -rf /etc/munge/munge.key
    python3 /etc/flux/manager/convert_munge_key.py ${mungeKey} /etc/munge/munge.key
+   sudo chmod u=r,g=,o= /etc/munge/munge.key
+   sudo chown munge:munge /etc/munge/munge.key 
 else
    /usr/sbin/create-munge-key
 fi

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -32,6 +32,7 @@ module "management_node" {
     login_node_specs   = jsonencode(var.login_node_specs)
     nfs_mounts         = var.cluster_storage
     broker_config      = var.broker_config
+    resource_hosts     = var.resource_hosts
 }
 
 module "login_nodes" {
@@ -60,7 +61,6 @@ module "login_nodes" {
     }
 
     nfs_mounts      = var.cluster_storage
-    broker_config   = var.broker_config
 }
 
 module "compute_nodes" {
@@ -94,6 +94,5 @@ module "compute_nodes" {
     }
 
     login_node_specs  = jsonencode(var.login_node_specs)
-    broker_config     = var.broker_config
     nfs_mounts        = var.cluster_storage
 }

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -33,6 +33,7 @@ module "management_node" {
     nfs_mounts         = var.cluster_storage
     broker_config      = var.broker_config
     resource_hosts     = var.resource_hosts
+    curve_cert         = var.curve_cert
 }
 
 module "login_nodes" {

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -34,6 +34,7 @@ module "management_node" {
     broker_config      = var.broker_config
     resource_hosts     = var.resource_hosts
     curve_cert         = var.curve_cert
+    munge_key          = var.munge_key
 }
 
 module "login_nodes" {

--- a/tf/modules/compute/main.tf
+++ b/tf/modules/compute/main.tf
@@ -62,7 +62,6 @@ module "flux_compute_instance_template" {
 
     metadata             = { 
         "boot-script"      : var.boot_script
-        "broker-config"    : var.broker_config
         "login-node-specs" : var.login_node_specs
         "enable-oslogin"   : "TRUE",
         "flux-manager"     : "${var.manager}",

--- a/tf/modules/compute/variables.tf
+++ b/tf/modules/compute/variables.tf
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "broker_config" {
-    description = "A custom broker config (system.toml) to provide to the manager"
-    type        = string
-    default     = ""
-    nullable    = true
-}
-
 variable "automatic_restart" {
   type        = bool
   description = "(Optional) Specifies whether the instance should be automatically restarted if it is terminated by Compute Engine (not terminated by a user)."

--- a/tf/modules/login/main.tf
+++ b/tf/modules/login/main.tf
@@ -45,7 +45,6 @@ module "flux_login_instance_template" {
     source_image_project = local.login_images["${var.machine_arch}"].project
     metadata             = { 
         "boot-script"    : var.boot_script,
-        "broker-config"  : var.broker_config,
         "enable-oslogin" : "TRUE",
         "flux-manager"   : "${var.manager}",
         "VmDnsSetting"   : "GlobalDefault",

--- a/tf/modules/login/variables.tf
+++ b/tf/modules/login/variables.tf
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "broker_config" {
-    description = "A custom broker config (system.toml) to provide to the manager"
-    type        = string
-    default     = ""
-    nullable    = true
-}
-
 variable "boot_script" {
     description = "(Optional) the name of a file containing a script to be executed on compute nodes at boot time"
     type        = string

--- a/tf/modules/management/main.tf
+++ b/tf/modules/management/main.tf
@@ -37,7 +37,8 @@ module "flux_manager_instance_template" {
         "login-node-specs"   : var.login_node_specs
         "broker-config"      : var.broker_config
         "resource-hosts"     : var.resource_hosts
-        "curve-cert"     : var.curve_cert
+        "curve-cert"         : var.curve_cert
+        "munge-key"          : var.munge_key
     }
 }
 

--- a/tf/modules/management/main.tf
+++ b/tf/modules/management/main.tf
@@ -36,6 +36,7 @@ module "flux_manager_instance_template" {
         "compute-node-specs" : var.compute_node_specs
         "login-node-specs"   : var.login_node_specs
         "broker-config"      : var.broker_config
+        "resource-hosts"     : var.resource_hosts
     }
 }
 

--- a/tf/modules/management/main.tf
+++ b/tf/modules/management/main.tf
@@ -37,6 +37,7 @@ module "flux_manager_instance_template" {
         "login-node-specs"   : var.login_node_specs
         "broker-config"      : var.broker_config
         "resource-hosts"     : var.resource_hosts
+        "curve-cert"     : var.curve_cert
     }
 }
 

--- a/tf/modules/management/variables.tf
+++ b/tf/modules/management/variables.tf
@@ -26,6 +26,13 @@ variable "resource_hosts" {
     nullable    = true
 }
 
+variable "curve_cert" {
+    description = "A custom curve certificate for bursting"
+    type        = string
+    default     = ""
+    nullable    = true
+}
+
 variable "compute_node_specs" {
     description = "A JSON encoded list of maps each with the keys: 'name_prefix', 'machin_arch', 'machine_type', and 'instances' which describe the compute node instances to create"
     type        = string

--- a/tf/modules/management/variables.tf
+++ b/tf/modules/management/variables.tf
@@ -19,6 +19,13 @@ variable "broker_config" {
     nullable    = true
 }
 
+variable "resource_hosts" {
+    description = "A custom listing of hosts for resource generation"
+    type        = string
+    default     = ""
+    nullable    = true
+}
+
 variable "compute_node_specs" {
     description = "A JSON encoded list of maps each with the keys: 'name_prefix', 'machin_arch', 'machine_type', and 'instances' which describe the compute node instances to create"
     type        = string

--- a/tf/modules/management/variables.tf
+++ b/tf/modules/management/variables.tf
@@ -33,6 +33,13 @@ variable "curve_cert" {
     nullable    = true
 }
 
+variable "munge_key" {
+    description = "A custom munge key"
+    type        = string
+    default     = ""
+    nullable    = true
+}
+
 variable "compute_node_specs" {
     description = "A JSON encoded list of maps each with the keys: 'name_prefix', 'machin_arch', 'machine_type', and 'instances' which describe the compute node instances to create"
     type        = string

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -19,9 +19,15 @@ variable "broker_config" {
     nullable    = true
 }
 
-
 variable "resource_hosts" {
     description = "A custom hostlist name for flux resource generation"
+    type        = string
+    default     = ""
+    nullable    = true
+}
+
+variable "curve_cert" {
+    description = "A custom curve certificate for bursting"
     type        = string
     default     = ""
     nullable    = true

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -19,6 +19,14 @@ variable "broker_config" {
     nullable    = true
 }
 
+
+variable "resource_hosts" {
+    description = "A custom hostlist name for flux resource generation"
+    type        = string
+    default     = ""
+    nullable    = true
+}
+
 variable "cluster_storage" { 
     description = "A map with keys 'share' and 'mountpoint' describing an NFS export and its intended mount point"
     type        = map(string)

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -33,6 +33,13 @@ variable "curve_cert" {
     nullable    = true
 }
 
+variable "munge_key" {
+    description = "A custom munge key"
+    type        = string
+    default     = ""
+    nullable    = true
+}
+
 variable "cluster_storage" { 
     description = "A map with keys 'share' and 'mountpoint' describing an NFS export and its intended mount point"
     type        = map(string)


### PR DESCRIPTION
the flux resource generation needs to account for the bursted cluster hosts, so we can try this by allowing for providing a custom lists of hosts.

This also removes the un-needed broker_config from login and compute nodes, which don't use it.